### PR TITLE
This plugin isn't copatible with PM4

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,7 +1,7 @@
 name: BuffShop
 main: i3rain\Main
 version: 1.0.0
-api: [3.0.0, 4.0.0]
+api: 3.0.0
 author: i3rain
 commands:
  buffs:


### PR DESCRIPTION
Do not use API 4 at the api tag in the plugin.yml, when the plugin is writing in PM3.